### PR TITLE
修改cpp，使其能够支持sock传输，避免大小端的问题

### DIFF
--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -50,7 +50,7 @@ int main(int argc, char const *argv[])
     }
 
     std::cout << "box Serialize Success, " << box.GetSerializedBytes() << " bytes \n";
-
+    std::cout << "box Serialize Success, " << box.GetSerializedBuffer() << "\n";
     TlvBox boxes;
     boxes.PutObjectValue(TEST_TYPE_a, box);
     

--- a/cpp/tlv.cpp
+++ b/cpp/tlv.cpp
@@ -9,61 +9,79 @@
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; version 2 of the License.  
  */
-
+#pragma one
 #include <string.h>
+#include <stdio.h>
+#include <stdint.h>
 #include "tlv.h"
- 
+#define TLV_BUF_SIZE 24
 namespace tlv
 {
 
 Tlv::Tlv(int type,bool value) : mType(type)
 {
-    Initialize(&value,sizeof(bool));
+    char buf[TLV_BUF_SIZE]; 
+    buf[0]=value?'0':'1';
+    Initialize(buf,1);
 }
 
 Tlv::Tlv(int type,char value) : mType(type)
 {
-    Initialize(&value,sizeof(char));
+    char buf[TLV_BUF_SIZE]; 
+    buf[0]=value;
+    Initialize(buf,1);
 }
 
 Tlv::Tlv(int type,short value) : mType(type)
 {
-    Initialize(&value,sizeof(short));
+    char buf[TLV_BUF_SIZE];
+    size_t len=snprintf(buf,sizeof(buf),"%hx",value);
+    Initialize(buf,len);
 }
 
 Tlv::Tlv(int type,int value) : mType(type)
 {
-    Initialize(&value,sizeof(int));
+    char buf[TLV_BUF_SIZE];
+    size_t len=snprintf(buf,sizeof(buf),"%x",value);
+    Initialize(buf,len);
 }
 
 Tlv::Tlv(int type,long value) : mType(type)
 {
-    Initialize(&value,sizeof(long));
+    char buf[TLV_BUF_SIZE];
+    size_t len=snprintf(buf,sizeof(buf),"%lx",value);
+    Initialize(buf,len);
 }
 
 Tlv::Tlv(int type,long long value) : mType(type)
 {
-    Initialize(&value,sizeof(long long));
+    char buf[TLV_BUF_SIZE];
+    size_t len=snprintf(buf,sizeof(buf),"%llx",value);
+    Initialize(buf,len);
 }
 
 Tlv::Tlv(int type,float value) : mType(type)
 {
-    Initialize(&value,sizeof(float));
+    char buf[TLV_BUF_SIZE];
+    size_t len=snprintf(buf,sizeof(buf),"%f",value);
+    Initialize(buf,len);
 }
 
 Tlv::Tlv(int type,double value) : mType(type)
 {
-    Initialize(&value,sizeof(double));
+    char buf[TLV_BUF_SIZE];
+    size_t len=snprintf(buf,sizeof(buf),"%lf",value);
+    Initialize(buf,len);
 }
 
 Tlv::Tlv(int type,char* value) : mType(type)
 {
-    Initialize(value,strlen(value)+1);
+    Initialize(value,strlen(value));
 }
 
 Tlv::Tlv(int type,std::string value) : mType(type)
 {
-    Initialize(value.c_str(),value.size()+1);
+    Initialize(value.c_str(),value.size());
 }
 
 Tlv::Tlv(int type,unsigned char *value,int length) : mType(type)
@@ -75,6 +93,99 @@ Tlv::Tlv(int type,const Tlv& value) : mType(type)
 {
     Initialize(value.GetValue(),value.GetLength());
 }
+bool Tlv::to_bool(bool&value){
+    if(!mValue){
+        return false;
+    }
+    switch(mLength){
+        case 1:
+            switch(mValue[0]){
+                case '0':
+                    value=false;
+                    return true;
+                case '1':
+                    value=true;
+                    return true;
+                default:
+                    return false;
+            }
+            return true;
+        default:
+            return false;
+    }
+    return false;
+}
+bool Tlv::to_char(char&value){
+    if(!mValue||mLength!=1){
+        return false;
+    }
+    value=mValue[0];
+    return true;
+}
+
+bool Tlv::to_short(short&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    sscanf((char*)mValue,"%hx",&value);
+    return true;
+}
+bool Tlv::to_int(int&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    sscanf((char*)mValue,"%x",&value);
+    return true;
+}
+bool Tlv::to_long(long&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    sscanf((char*)mValue,"%lx",&value);
+    return true;
+}
+bool Tlv::to_longlong(long long&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    sscanf((char*)mValue,"%llx",&value);
+    return true;
+}
+bool Tlv::to_float(float&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    sscanf((char*)mValue,"%f",&value);
+    return true;
+}
+bool Tlv::to_double(double&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    sscanf((char*)mValue,"%lf",&value);
+    return true;
+}
+bool Tlv::to_string(string&value){
+    if(!mValue||mLength<=0){
+        return false;
+    }
+    value.assign((char*)mValue,(size_t)mLength);
+    return true;
+}
+bool Tlv::isdigit(){
+    if(!mValue){
+        return false;
+    }
+    if(!(mValue[0]=='+'||mValue[0]=='-'||mValue[0]>='0'&&mValue[0]<='9')){
+        return false;
+    }
+    for(uint32_t i=1;i<mLength;i++){
+        if(!(mValue[i]>='0'||mValue[i]<='9')){
+            return false;
+        }
+    }
+    return false;
+}
 
 Tlv::~Tlv()
 {
@@ -84,8 +195,9 @@ Tlv::~Tlv()
 void Tlv::Initialize(const void *value,int length)
 {
     mLength = length;
-    mValue = new unsigned char[length];
+    mValue = new unsigned char[length+1];
     memcpy(mValue,value,length);
+    mValue[length]='\0';
 }
 
 int Tlv::GetType() const

--- a/cpp/tlv.h
+++ b/cpp/tlv.h
@@ -14,7 +14,7 @@
 #define _TLV_H_
 
 #include <string>
-
+using std::string;
 namespace tlv
 {
 
@@ -33,6 +33,15 @@ public:
     Tlv(int type,std::string value);
     Tlv(int type,unsigned char *value,int length);    
     Tlv(int type,const Tlv& value);
+    bool to_bool(bool&value);
+    bool to_char(char&value);
+    bool to_short(short&value);
+    bool to_int(int&value);
+    bool to_long(long&value);
+    bool to_longlong(long long&value);
+    bool to_float(float&value);
+    bool to_double(double&value);
+    bool to_string(string&value);
     ~Tlv();
 
 public:
@@ -41,6 +50,7 @@ public:
     unsigned char *GetValue() const;
 
 private:
+    bool isdigit();
     Tlv(const Tlv& c);
     Tlv &operator=(const Tlv &c);
     void Initialize(const void *value,int length);


### PR DESCRIPTION
对数据进行格式化，而不是直接内存拷贝。这样可以通过socket传输，进而避免大小端问题;缺点是将type和length格式化成16字节，比原来增加8字节开销