### PR TITLE
fix null-ptr related memory issues

### DIFF
--- a/cpp/tlv.cpp
+++ b/cpp/tlv.cpp
@@ -89,6 +89,12 @@ Tlv::~Tlv()
 void Tlv::Initialize(const void *value, int length)
 {
     mLength = length;
+    if(value == nullptr)
+    {
+        mValue = nullptr;
+        return;
+    }
+
     mValue = new unsigned char[length];
     memcpy(mValue, value, length);
 }

--- a/cpp/tlv_box.cpp
+++ b/cpp/tlv_box.cpp
@@ -90,7 +90,8 @@ bool TlvBox::Serialize()
         int nwlength = htonl(length);
         memcpy(mSerializedBuffer+offset, &nwlength, sizeof(int));
         offset += sizeof(int);
-        memcpy(mSerializedBuffer+offset, itor->second->GetValue(), length);        
+        if(length)
+            memcpy(mSerializedBuffer+offset, itor->second->GetValue(), length);
         offset += length;
     }
 


### PR DESCRIPTION
This commit fixes memory corruption, while calling TlvBox::PutNoValue